### PR TITLE
fix(frontend): tools dark mode background color

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,6 +17,11 @@
             border-radius: 8px;
             box-shadow: 0 2px 4px rgba(0,0,0,0.1);
         }
+        @media (prefers-color-scheme: dark) {
+            .tool {
+                background-color: #242933;
+            }
+        }
         table {
             width: 100%;
             border-collapse: collapse;


### PR DESCRIPTION
fix #2 
修复硬编码`background-color`导致前端`tools`模块显示异常
添加颜色是`bamboo.css`的`--b-btn-bg`